### PR TITLE
Fix MB Yoast SEO Notice Error

### DIFF
--- a/class-mb-yoast-seo.php
+++ b/class-mb-yoast-seo.php
@@ -19,7 +19,7 @@ class MB_Yoast_SEO {
 
 		// Only for posts.
 		$screen = get_current_screen();
-		if ( 'post' !== $screen->base ) {
+		if ( ! is_object( $screen ) || 'post' !== $screen->base ) {
 			return;
 		}
 


### PR DESCRIPTION
Notice: Trying to get property 'base' of non-object in /var/www/html/wp-content/plugins/meta-box-aio/vendor/meta-box/mb-yoast-seo/class-mb-yoast-seo.php on line 22

https://metabox.io/support/topic/a-problem-with-no-object-in-class-mb-yoast-seo-php